### PR TITLE
Feat/product out

### DIFF
--- a/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
@@ -201,17 +201,18 @@ public class DatabaseInitializer implements CommandLineRunner {
                 END;
                 """,
                 """
-                CREATE TRIGGER IF NOT EXISTS after_product_entries_insert
-                    AFTER INSERT
-                    ON product_entries
-                    FOR EACH ROW
-                BEGIN
-                    DECLARE var_relatedUserId INT;
-                    SELECT relatedUserId INTO var_relatedUserId FROM product_entries ORDER BY id DESC LIMIT 1;
-                
-                    INSERT INTO transaction_log (transactionType, tableName, relatedUserId, details, uuid)
-                    VALUES ('INSERT', 'product_entries', var_relatedUserId, CONCAT('Inserted product entry with id: ', NEW.id), UUID());
-                END;
+               CREATE TRIGGER IF NOT EXISTS after_product_entries_insert
+                        AFTER INSERT
+                        ON product_entries
+                        FOR EACH ROW
+                    BEGIN
+                        DECLARE var_relatedUserUUID UUID;
+                        SELECT relatedUserUUID INTO var_relatedUserUUID FROM product_entries ORDER BY id DESC LIMIT 1;
+                    
+                        INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
+                        VALUES ('INSERT', 'product_entries', var_relatedUserUUID, CONCAT('Inserted product entry with id: ', NEW.id), UUID());
+                    END;
+                    
                 """,
                 """
                 CREATE TRIGGER IF NOT EXISTS after_product_entries_update

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
@@ -41,9 +41,9 @@ public class DatabaseInitializer implements CommandLineRunner {
               AND measurementUnit = NEW.measurementUnit;
         ELSE
             -- If the product does not exist, insert a new record with uuid
-            INSERT INTO stock (id, productName, measurementUnit, quantity, unitPrice, totalAmount, supplierId, uuid)
+            INSERT INTO stock (id, productName, measurementUnit, quantity, unitPrice, totalAmount, uuid)
             VALUES (NEW.id, NEW.productName, NEW.measurementUnit, NEW.quantity, NEW.unitPrice,
-                    NEW.quantity * NEW.unitPrice, NEW.supplierId, UUID());
+                    NEW.quantity * NEW.unitPrice, UUID());
         END IF;
     END;
     """;
@@ -201,18 +201,17 @@ public class DatabaseInitializer implements CommandLineRunner {
                 END;
                 """,
                 """
-               CREATE TRIGGER IF NOT EXISTS after_product_entries_insert
-                        AFTER INSERT
-                        ON product_entries
-                        FOR EACH ROW
-                    BEGIN
-                        DECLARE var_relatedUserUUID UUID;
-                        SELECT relatedUserUUID INTO var_relatedUserUUID FROM product_entries ORDER BY id DESC LIMIT 1;
-                    
-                        INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
-                        VALUES ('INSERT', 'product_entries', var_relatedUserUUID, CONCAT('Inserted product entry with id: ', NEW.id), UUID());
-                    END;
-                    
+                CREATE TRIGGER IF NOT EXISTS after_product_entries_insert
+                    AFTER INSERT
+                    ON product_entries
+                    FOR EACH ROW
+                BEGIN
+                    DECLARE var_relatedUserUUID UUID;
+                    SELECT relatedUserUUID INTO var_relatedUserUUID FROM product_entries ORDER BY id DESC LIMIT 1;
+                
+                    INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
+                    VALUES ('INSERT', 'product_entries', var_relatedUserUUID, CONCAT('Inserted product entry with id: ', NEW.id), UUID());
+                END;
                 """,
                 """
                 CREATE TRIGGER IF NOT EXISTS after_product_entries_update
@@ -242,68 +241,38 @@ public class DatabaseInitializer implements CommandLineRunner {
                 END;
                 """,
                 """
-                CREATE TRIGGER IF NOT EXISTS after_product_outs_insert
-                    AFTER INSERT
-                    ON product_outs
-                    FOR EACH ROW
-                BEGIN
-                    DECLARE var_relatedUserId INT;
-                    SELECT relatedUserId INTO var_relatedUserId FROM product_outs ORDER BY id DESC LIMIT 1;
-                
-                    INSERT INTO transaction_log (transactionType, tableName, relatedUserId, details, uuid)
-                    VALUES ('INSERT', 'product_outs', var_relatedUserId, CONCAT('Inserted product out with id: ', NEW.id), UUID());
-                END;
-                """,
-                """
-                CREATE TRIGGER IF NOT EXISTS after_product_outs_insert
-                    AFTER INSERT
-                    ON product_outs
-                    FOR EACH ROW
-                BEGIN
-                    DECLARE var_relatedUserId INT;
-                    SELECT relatedUserId INTO var_relatedUserId FROM product_outs ORDER BY id DESC LIMIT 1;
-                
-                    INSERT INTO transaction_log (transactionType, tableName, relatedUserId, details, uuid)
-                    VALUES ('INSERT', 'product_outs', var_relatedUserId, CONCAT('Inserted product out with id: ', NEW.id), UUID());
-                END;
+                 CREATE TRIGGER IF NOT EXISTS after_product_outs_insert
+                                                    AFTER INSERT
+                                                    ON product_outs
+                                                    FOR EACH ROW
+                                                BEGIN
+                                                    DECLARE var_relatedUserUUID UUID;
+                                                    SELECT relatedUserUUID INTO var_relatedUserUUID FROM product_outs ORDER BY id DESC LIMIT 1;
+                                              
+                                                    INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
+                                                    VALUES ('INSERT', 'product_outs', var_relatedUserId, CONCAT('Inserted product out with id: ', NEW.id), UUID());
+                                    END;
                 """,
                 """
                 CREATE TRIGGER IF NOT EXISTS after_product_outs_update
-                    AFTER UPDATE
-                    ON product_outs
-                    FOR EACH ROW
-                BEGIN
-                    DECLARE var_relatedUserId INT;
-                    SELECT relatedUserId INTO var_relatedUserId FROM product_outs ORDER BY id DESC LIMIT 1;
-                
-                    INSERT INTO transaction_log (transactionType, tableName, relatedUserId, details, uuid)
-                    VALUES ('UPDATE', 'product_outs', var_relatedUserId, CONCAT('Updated product out with id: ', NEW.id), UUID());
-                END;
+                                AFTER UPDATE
+                                ON product_outs
+                                FOR EACH ROW
+                            BEGIN
+                                INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
+                                VALUES ('UPDATE', 'product_outs', NEW.relatedUserUUID, CONCAT('Updated product out with id: ', NEW.id), UUID_TO_BIN(UUID()));
+                            END;
                 """,
+
                 """
-                CREATE TRIGGER IF NOT EXISTS after_product_outs_update
-                    AFTER UPDATE
-                    ON product_outs
-                    FOR EACH ROW
-                BEGIN
-                    DECLARE var_relatedUserId INT;
-                    SELECT relatedUserId INTO var_relatedUserId FROM product_outs ORDER BY id DESC LIMIT 1;
-                
-                    INSERT INTO transaction_log (transactionType, tableName, relatedUserId, details, uuid)
-                    VALUES ('UPDATE', 'product_outs', var_relatedUserId, CONCAT('Updated product out with id: ', NEW.id), UUID());
-                END;
-                """,
-                """
+                        
                 CREATE TRIGGER IF NOT EXISTS after_product_outs_delete
                     AFTER DELETE
                     ON product_outs
                     FOR EACH ROW
                 BEGIN
-                    DECLARE var_relatedUserId INT;
-                    SELECT relatedUserId INTO var_relatedUserId FROM product_outs ORDER BY id DESC LIMIT 1;
-                
-                    INSERT INTO transaction_log (transactionType, tableName, relatedUserId, details, uuid)
-                    VALUES ('DELETE', 'product_outs', var_relatedUserId, CONCAT('Deleted product out with name: ', OLD.productName), UUID());
+                    INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
+                    VALUES ('DELETE', 'product_outs', OLD.relatedUserUUID, CONCAT('Deleted product out with name: ', OLD.productName), UUID_TO_BIN(UUID()));
                 END;
                 """
         };

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
@@ -18,35 +18,35 @@ public class DatabaseInitializer implements CommandLineRunner {
     public void run(String... args) throws Exception {
 
         String createProductEntriesToStockTrigger = """
-                 CREATE TRIGGER IF NOT EXISTS product_entries_to_stock
-                    AFTER INSERT
-                    ON product_entries
-                    FOR EACH ROW
-                BEGIN
-                    DECLARE existing_quantity INT;
-                
-                    -- Check if the product already exists in the stock table
-                    SELECT quantity
-                    INTO existing_quantity
-                    FROM stock
-                    WHERE productName = NEW.productName
-                      AND measurementUnit = NEW.measurementUnit;
-                
-                    IF existing_quantity IS NOT NULL THEN
-                        -- If the product exists, update the quantity and totalAmount
-                    UPDATE stock
-                    SET quantity     = quantity + NEW.quantity,
-                        totalAmount = (quantity) * NEW.unitPrice
-                    WHERE productName = NEW.productName
-                      AND measurementUnit = NEW.measurementUnit;
-                    ELSE
-                        -- If the product does not exist, insert a new record with totalAmount
-                        INSERT INTO stock (id, productName, measurementUnit, quantity, unitPrice, totalAmount, supplierId)
-                        VALUES (NEW.id, NEW.productName, NEW.measurementUnit, NEW.quantity, NEW.unitPrice,
-                                NEW.quantity * NEW.unitPrice, NEW.supplierId);
-                END IF;
-                END;
-                """;
+    CREATE TRIGGER IF NOT EXISTS product_entries_to_stock
+        AFTER INSERT
+        ON product_entries
+        FOR EACH ROW
+    BEGIN
+        DECLARE existing_quantity INT;
+
+        -- Check if the product already exists in the stock table
+        SELECT quantity
+        INTO existing_quantity
+        FROM stock
+        WHERE productName = NEW.productName
+          AND measurementUnit = NEW.measurementUnit;
+
+        IF existing_quantity IS NOT NULL THEN
+            -- If the product exists, update the quantity and totalAmount
+            UPDATE stock
+            SET quantity     = quantity + NEW.quantity,
+                totalAmount = (quantity + NEW.quantity) * NEW.unitPrice
+            WHERE productName = NEW.productName
+              AND measurementUnit = NEW.measurementUnit;
+        ELSE
+            -- If the product does not exist, insert a new record with uuid
+            INSERT INTO stock (id, productName, measurementUnit, quantity, unitPrice, totalAmount, supplierId, uuid)
+            VALUES (NEW.id, NEW.productName, NEW.measurementUnit, NEW.quantity, NEW.unitPrice,
+                    NEW.quantity * NEW.unitPrice, NEW.supplierId, UUID());
+        END IF;
+    END;
+    """;
 
         String createProductOutsToStockTrigger = """
                 CREATE TRIGGER IF NOT EXISTS product_outs_to_stock

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/config/DatabaseInitializer.java
@@ -271,11 +271,35 @@ public class DatabaseInitializer implements CommandLineRunner {
                     ON product_outs
                     FOR EACH ROW
                 BEGIN
+                    DECLARE var_relatedUserUUID UUID;
+                    SELECT relatedUserUUID INTO var_relatedUserUUID FROM product_outs ORDER BY id DESC LIMIT 1;
                     INSERT INTO transaction_log (transactionType, tableName, relatedUserUUID, details, uuid)
                     VALUES ('DELETE', 'product_outs', OLD.relatedUserUUID, CONCAT('Deleted product out with name: ', OLD.productName), UUID_TO_BIN(UUID()));
                 END;
                 """
         };
+
+        String createProductOutsDeleteTrigger =
+    """
+    CREATE TRIGGER IF NOT EXISTS after_delete_product_outs
+        AFTER DELETE
+        ON product_outs
+        FOR EACH ROW
+    BEGIN
+        UPDATE stock
+        SET quantity = quantity + OLD.quantity,
+            totalAmount = (quantity + OLD.quantity) * unitPrice
+        WHERE productName = OLD.productName
+          AND measurementUnit = OLD.measurementUnit;
+    END;
+""";
+
+        try {
+            jdbcTemplate.execute(createProductOutsDeleteTrigger);
+            logger.info("Trigger 'after_delete_product_outs' created successfully.");
+        } catch (Exception e) {
+            logger.error("Error creating trigger 'after_delete_product_outs': ", e);
+        }
 
         try {
             jdbcTemplate.execute(createProductEntriesToStockTrigger);

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductEntry/ProductEntryController.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductEntry/ProductEntryController.java
@@ -33,6 +33,10 @@ public class ProductEntryController {
         return productEntryService.findByUuid(uuid);
     }
 
+    @GetMapping("/user/{uuid}")
+    public ResponseEntity<ApiResponse<List<ProductEntry>>>getEntriesByUser(@PathVariable UUID uuid){
+        return productEntryService.findByUser(uuid);
+    }
     @DeleteMapping("/{uuid}")
     public ResponseEntity<ApiResponse<String>> deleteById(@PathVariable UUID uuid){
         return productEntryService.deleteByUuid(uuid);

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductEntry/ProductEntryDto.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductEntry/ProductEntryDto.java
@@ -3,6 +3,7 @@ package utez.edu.mx.warehousemanager_backend.controller.ProductEntry;
 import lombok.Value;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 /**
  * DTO for {@link utez.edu.mx.warehousemanager_backend.model.ProductEntry}
@@ -16,5 +17,6 @@ public class ProductEntryDto implements Serializable {
     double unitPrice;
     double totalAmount;
     String measurementUnit;
-    Integer relatedUserId;
+    UUID relatedUserUUID;
+
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/OutDto.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/OutDto.java
@@ -1,0 +1,12 @@
+package utez.edu.mx.warehousemanager_backend.controller.ProductOut;
+
+import lombok.Value;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Value
+public class OutDto implements Serializable {
+    String receiverName;
+    List<ProductOutDto> productOutList;
+}

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/ProductOutController.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/ProductOutController.java
@@ -3,9 +3,11 @@ package utez.edu.mx.warehousemanager_backend.controller.ProductOut;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import utez.edu.mx.warehousemanager_backend.config.ApiResponse;
+import utez.edu.mx.warehousemanager_backend.model.ProductEntry;
 import utez.edu.mx.warehousemanager_backend.model.ProductOut;
 import utez.edu.mx.warehousemanager_backend.service.ProductOutService;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/productOut")
@@ -30,4 +32,14 @@ public class ProductOutController {
     public ResponseEntity<ApiResponse<ProductOut>> findByUuid(@PathVariable String uuid){
         return productOutService.findByUuid(uuid);
     }
+
+    @GetMapping("/user/{uuid}")
+    public ResponseEntity<ApiResponse<List<ProductOut>>>getEntriesByUser(@PathVariable UUID uuid){
+        return productOutService.findByUser(uuid);
+    }
+    @DeleteMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<String>> deleteById(@PathVariable UUID uuid){
+        return productOutService.deleteByUuid(uuid);
+    }
+
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/ProductOutController.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/ProductOutController.java
@@ -17,7 +17,7 @@ public class ProductOutController {
     }
 
     @PostMapping("/")
-    public ResponseEntity<ApiResponse<ProductOut>> save(@RequestBody ProductOutDto dto){
+    public ResponseEntity<ApiResponse<List<ProductOutDto>>> save(@RequestBody OutDto dto){
         return productOutService.save(dto);
     }
 

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/ProductOutDto.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/controller/ProductOut/ProductOutDto.java
@@ -1,6 +1,7 @@
 package utez.edu.mx.warehousemanager_backend.controller.ProductOut;
 import lombok.Value;
 import java.io.Serializable;
+import java.util.UUID;
 
 /**
  * DTO for {@link utez.edu.mx.warehousemanager_backend.model.ProductOut}
@@ -12,6 +13,6 @@ public class ProductOutDto implements Serializable {
     int quantity;
     double unitPrice;
     double totalAmount;
-    String reciverName;
-    Integer relatedUserId;
+    String receiverName;
+    UUID relatedUserUUID;
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/model/ProductEntry.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/model/ProductEntry.java
@@ -36,7 +36,7 @@ public class ProductEntry {
     @JoinColumn(name = "supplierId", nullable = false)
     private Supplier supplier;
 
-    private Integer relatedUserId;
+    private UUID relatedUserUUID;
 
     @PrePersist
     public void generateUUID() {

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/model/ProductOut.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/model/ProductOut.java
@@ -25,9 +25,8 @@ public class ProductOut {
     private double unitPrice;
     private double totalAmount;
     private LocalDateTime outDate = LocalDateTime.now();
-    private String reciverName;
-    private Integer relatedUserId;
-
+    private String receiverName;
+    private UUID relatedUserUUID;
 
 
     @PrePersist

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/model/Stock.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/model/Stock.java
@@ -19,7 +19,7 @@ public class Stock {
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "id", nullable = false)
    private Integer id;
-   private UUID uuid;
+   private String uuid;
    private String productName;
    private String measurementUnit;
    private int quantity;
@@ -30,12 +30,6 @@ public class Stock {
    private Integer supplierId;
 
 
-    @PrePersist
-    public void generateUUID() {
-        if (uuid == null) {
-            uuid = UUID.randomUUID();
-        }
-    }
 
 
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/model/Stock.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/model/Stock.java
@@ -27,9 +27,4 @@ public class Stock {
    private double unitPrice;
    @Column(columnDefinition = "DECIMAL(10, 2) DEFAULT 00.00")
    private double totalAmount;
-   private Integer supplierId;
-
-
-
-
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/repository/ProductEntryRepository.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/repository/ProductEntryRepository.java
@@ -1,7 +1,6 @@
 package utez.edu.mx.warehousemanager_backend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import utez.edu.mx.warehousemanager_backend.model.ProductEntry;
 
 import java.util.List;

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/repository/ProductEntryRepository.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/repository/ProductEntryRepository.java
@@ -4,10 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import utez.edu.mx.warehousemanager_backend.model.ProductEntry;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ProductEntryRepository extends JpaRepository<ProductEntry,Integer> {
 
     ProductEntry findByUuid(UUID uuid);
-
+    List <ProductEntry> findAllByRelatedUserUUID(UUID uuid);
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/repository/ProductOutRepository.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/repository/ProductOutRepository.java
@@ -4,7 +4,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import utez.edu.mx.warehousemanager_backend.model.ProductOut;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface ProductOutRepository extends JpaRepository<ProductOut, Integer> {
     @Query(value = "SELECT * FROM product_outs WHERE uuid=:uuid", nativeQuery = true)
     ProductOut findByUuid(String uuid);
+
+    ProductOut findByUuid(UUID uuid);
+
+    List<ProductOut> findAllByRelatedUserUUID(UUID uuid);
+
+
+
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductEntryService.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductEntryService.java
@@ -46,6 +46,7 @@ public class ProductEntryService {
                     .totalAmount(productEntryDto.getQuantity() * productEntryDto.getUnitPrice())
                     .entryDate(LocalDateTime.now())
                     .measurementUnit(productEntryDto.getMeasurementUnit())
+                    .relatedUserUUID(productEntryDto.getRelatedUserUUID())
                     .build();
             productEntryRepository.save(productEntry);
         }
@@ -124,5 +125,23 @@ public class ProductEntryService {
                 HttpStatus.NOT_FOUND
         );
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    public ResponseEntity<ApiResponse<List<ProductEntry>>> findByUser(UUID uuid) {
+        List<ProductEntry> productEntries = productEntryRepository.findAllByRelatedUserUUID(uuid);
+        if (!productEntries.isEmpty()) {
+            ApiResponse<List<ProductEntry>> response = new ApiResponse<>(
+                    productEntries,
+                    "Product entries found for the related user",
+                    HttpStatus.OK
+            );
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } else {
+            ApiResponse<List<ProductEntry>> response = new ApiResponse<>(
+                    "No product entries found for the related user",
+                    HttpStatus.NOT_FOUND
+            );
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductOutService.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductOutService.java
@@ -54,11 +54,6 @@ public class ProductOutService {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    private String validateProductOut(ProductOutDto productOutDto) {
-        // Implement validation logic here
-        return null;
-    }
-
     public ResponseEntity<ApiResponse<ProductOut>> findByUuid(String uuid){
         if(productOutRepository.findByUuid(uuid) != null){
             ApiResponse<ProductOut> response = new ApiResponse<>(

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductOutService.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductOutService.java
@@ -6,11 +6,13 @@ import org.springframework.stereotype.Service;
 import utez.edu.mx.warehousemanager_backend.config.ApiResponse;
 import utez.edu.mx.warehousemanager_backend.controller.ProductOut.OutDto;
 import utez.edu.mx.warehousemanager_backend.controller.ProductOut.ProductOutDto;
+import utez.edu.mx.warehousemanager_backend.model.ProductEntry;
 import utez.edu.mx.warehousemanager_backend.model.ProductOut;
 import utez.edu.mx.warehousemanager_backend.repository.ProductOutRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class ProductOutService {
@@ -85,5 +87,42 @@ public class ProductOutService {
         return new ResponseEntity<>(response, HttpStatus.OK);
 
     }
+
+    public ResponseEntity<ApiResponse<String>> deleteByUuid(UUID uuid){
+        ProductOut productOut = productOutRepository.findByUuid(uuid);
+        if (productOut != null){
+            productOutRepository.delete(productOut);
+            ApiResponse<String> response = new ApiResponse<>(
+                    "Product out deleted",
+                    HttpStatus.OK
+            );
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        }
+        ApiResponse<String> response = new ApiResponse<>(
+                "Product out not found",
+                HttpStatus.NOT_FOUND
+        );
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    public ResponseEntity<ApiResponse<List<ProductOut>>> findByUser(UUID uuid) {
+        List<ProductOut> productOuts = productOutRepository.findAllByRelatedUserUUID(uuid);
+        if (!productOuts.isEmpty()) {
+            ApiResponse<List<ProductOut>> response = new ApiResponse<>(
+                    productOuts,
+                    "Product outs found for the related user",
+                    HttpStatus.OK
+            );
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } else {
+            ApiResponse<List<ProductOut>> response = new ApiResponse<>(
+                    "No product outs found for the related user",
+                    HttpStatus.NOT_FOUND
+            );
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
+
+
 
 }

--- a/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductOutService.java
+++ b/src/main/java/utez/edu/mx/warehousemanager_backend/service/ProductOutService.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import utez.edu.mx.warehousemanager_backend.config.ApiResponse;
+import utez.edu.mx.warehousemanager_backend.controller.ProductOut.OutDto;
 import utez.edu.mx.warehousemanager_backend.controller.ProductOut.ProductOutDto;
 import utez.edu.mx.warehousemanager_backend.model.ProductOut;
 import utez.edu.mx.warehousemanager_backend.repository.ProductOutRepository;
@@ -19,23 +20,41 @@ public class ProductOutService {
         this.productOutRepository = productOutRepository;
     }
 
-    public ResponseEntity<ApiResponse<ProductOut>> save (ProductOutDto dto) {
-        ProductOut savedProductOut = ProductOut.builder()
-                .productName(dto.getProductName())
-                .unitPrice(dto.getUnitPrice())
-                .quantity(dto.getQuantity())
-                .totalAmount(dto.getTotalAmount())
-                .measurementUnit(dto.getMeasurementUnit())
-                .outDate(LocalDateTime.now())
-                .reciverName(dto.getReciverName())
-                .build();
+    public ResponseEntity<ApiResponse<List<ProductOutDto>>> save (OutDto outDto){
+        for (ProductOutDto productOutDto : outDto.getProductOutList()) {
+            String validationError = validateProductOut(productOutDto);
+            if (validationError != null) {
+                ApiResponse<List<ProductOutDto>> response = new ApiResponse<>(
+                        validationError,
+                        HttpStatus.CONFLICT
+                );
+                return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+            }
 
-        ApiResponse<ProductOut> response = new ApiResponse<>(
-                productOutRepository.save(savedProductOut),
-                "New product out created",
+            ProductOut productOut = ProductOut.builder()
+                    .productName(productOutDto.getProductName())
+                    .quantity(productOutDto.getQuantity())
+                    .unitPrice(productOutDto.getUnitPrice())
+                    .totalAmount(productOutDto.getQuantity() * productOutDto.getUnitPrice())
+                    .outDate(LocalDateTime.now())
+                    .measurementUnit(productOutDto.getMeasurementUnit())
+                    .receiverName(productOutDto.getReceiverName())
+                    .relatedUserUUID(productOutDto.getRelatedUserUUID())
+                    .build();
+            productOutRepository.save(productOut);
+        }
+
+        ApiResponse<List<ProductOutDto>> response = new ApiResponse<>(
+                outDto.getProductOutList(),
+                "New product outs registered successfully",
                 HttpStatus.OK
         );
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private String validateProductOut(ProductOutDto productOutDto) {
+        // Implement validation logic here
+        return null;
     }
 
     public ResponseEntity<ApiResponse<ProductOut>> findByUuid(String uuid){
@@ -55,6 +74,7 @@ public class ProductOutService {
         }
 
     }
+
 
     public ResponseEntity<ApiResponse<List<ProductOut>>> findAll() {
         ApiResponse<List<ProductOut>> response = new ApiResponse<>(


### PR DESCRIPTION
Triggers were modified to receive UUIDs instead of IDs. Products are searched for using the user's UUID (inputs and outputs).
A trigger was added to reset stock when a product's output is canceled.
Product out functionality was completed.
The supplierId was removed from the Stock entity.

Create-drop is required to avoid errors.